### PR TITLE
Enable :visited pseudo-class on resources links

### DIFF
--- a/app/assets/stylesheets/decidim.scss
+++ b/app/assets/stylesheets/decidim.scss
@@ -221,3 +221,7 @@ body, h1, h2, h3, h4, h5, h6, p, a, span {
 .main-footer__badge {
   left: 14%;
 }
+
+.card__link:visited {
+  color: #6c399b;
+}


### PR DESCRIPTION
This PR aims to activate the :visited pseudo-class on card links, so the users can see which links they already viewed on the platform. 

i.e: 
<img width="918" alt="Capture d’écran 2021-08-16 à 15 04 00" src="https://user-images.githubusercontent.com/52420208/129568165-82a9f47a-70ea-4bca-91aa-0175073b4cd1.png">
