### PR TITLE
Fix annoucement when empty

### DIFF
--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -19,3 +19,11 @@
         fill: rgba($primary, .2);;
     }
 ```
+## Fix annoucement div displayed while empty
+
+- **app/cells/decidim/announcement_cell.rb**, from https://github.com/decidim/decidim/blob/release/0.24-stable/decidim-core/app/cells/decidim/announcement_cell.rb
+```ruby
+def empty_announcement?
+  clean_announcement.blank? || clean_announcement == "<p><br></p>"
+end
+``` 

--- a/app/assets/stylesheets/decidim.scss
+++ b/app/assets/stylesheets/decidim.scss
@@ -120,6 +120,10 @@ $google: #dd4b39;
   }
 }
 
+.topbar div {
+  align-items: center;
+}
+
 .main-footer__badge {
   left: 14%;
 }

--- a/app/cells/decidim/announcement_cell.rb
+++ b/app/cells/decidim/announcement_cell.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This cell renders an announcement
+  #
+  # The `model` is expected to be a Hash with two keys:
+  #   - `body` is mandatory, its the message to show
+  #   - `title` is mandatory, a title to show
+  #
+  # {
+  #   title: "...", # mandatory
+  #   body: "..." # mandatory
+  # }
+  #
+  # It can also receive a single value to show as text. It can either be a String
+  # or a value accepted by the `translated_attribute` method.
+  #
+  # As options, the cell accepts a Hash with these keys:
+  #   - `callout_class`: The Css class to apply. Default to `"secondary"`
+  #
+  class AnnouncementCell < Decidim::ViewModel
+    include Decidim::SanitizeHelper
+
+    def show
+      return if clean_body.blank? && empty_announcement?
+
+      render :show
+    end
+
+    private
+
+    def has_title?
+      announcement.is_a?(Hash) && announcement.has_key?(:title)
+    end
+
+    def callout_class
+      options[:callout_class] ||= "secondary"
+    end
+
+    def announcement
+      model
+    end
+
+    def clean_title
+      clean(announcement[:title])
+    end
+
+    def body
+      return announcement.presence unless announcement.is_a?(Hash)
+
+      announcement[:body].presence
+    end
+
+    def clean_body
+      return unless body
+
+      Array(body).map { |paragraph| tag.p(clean(paragraph)) }.join("")
+    end
+
+    def clean_announcement
+      clean(announcement)
+    end
+
+    def clean(value)
+      decidim_sanitize(translated_attribute(value))
+    end
+
+    def empty_announcement?
+      clean_announcement.blank? || clean_announcement == "<p><br></p>"
+    end
+  end
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -330,6 +330,33 @@ fr:
           title: Vous décidez du budget
           total_projects: Total de projets
     components:
+      proposals:
+        settings:
+          step:
+            default_sort_order: Tri des propositions par défaut
+            default_sort_order_options:
+              default: Par défaut
+              random: Aléatoire
+              recent: Les plus récentes
+              most_endorsed: Les plus soutenues
+              most_voted: Les plus votées
+              most_commented: Les plus commentées
+              most_followed: Les plus suivies
+              with_more_authors: Avec le plus d'auteurs
+          global:
+            default_sort_order: Tri des propositions par défaut
+            default_sort_order_options:
+              default: Par défaut
+              random: Aléatoire
+              recent: Les plus récentes
+              most_endorsed: Les plus soutenues
+              most_voted: Les plus votées
+              most_commented: Les plus commentées
+              most_followed: Les plus suivies
+              with_more_authors: Avec le plus d'auteurs
+            proposal_edit_time: Durée d'édition des propositions
+            proposal_edit_time_choices:
+              infinite: Autoriser l'édition des propositions pour une durée infinie
       budgets:
         settings:
           global:

--- a/spec/cells/decidim/announcement_cell_spec.rb
+++ b/spec/cells/decidim/announcement_cell_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe AnnouncementCell, type: :cell do
+    controller Decidim::LastActivitiesController
+
+    context "when passing a non-empty string" do
+      let(:announcement) { "My announcement" }
+
+      it "renders the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to have_css(".callout.announcement.cell-announcement")
+        expect(html).to have_text(announcement)
+      end
+    end
+
+    context "when passing an empty string" do
+      let(:announcement) { "" }
+
+      it "does not render the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to render_nothing
+      end
+    end
+
+    context "when passing an empty translations hash" do
+      let(:announcement) { { en: "" } }
+
+      it "does not render the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to render_nothing
+      end
+    end
+
+    context "when passing a non-empty translations hash" do
+      let(:announcement) { { en: "My announcement", ca: "Translated value" } }
+
+      it "renders the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to have_css(".callout.announcement.cell-announcement")
+        expect(html).to have_text("My announcement")
+      end
+    end
+
+    context "when passing empty html tags" do
+      let(:announcement) { { en: "<p><br></p>" } }
+
+      it "does not render the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to render_nothing
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to backport the fix for not displaying announcement when div is empty. 
It also add some missing translations on Proposals configuration and fixes a CSS display. 